### PR TITLE
CTCTRADERS-293 | Drop db before running scenarios

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+./drop_unloading_frontend_data.sh
 sbt -Dbrowser=firefox -Denvironment=local 'testOnly ctc.suites.Runner'

--- a/run_wip.sh
+++ b/run_wip.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+./drop_unloading_frontend_data.sh
 sbt -Dbrowser=chrome -Denvironment=local 'testOnly ctc.suites.Runner_WIP'

--- a/src/test/resources/features/UnloadingRemarks.feature
+++ b/src/test/resources/features/UnloadingRemarks.feature
@@ -53,7 +53,6 @@ Feature: Ability to submit unloading remarks
     When I clicked the submit button
     Then I should be on the confirmation page
 
-
   Scenario: 3 - Unloading Remarks with seals, adds new seals and changes the check seals section from CYA page
 
     And I am on the Unloading remarks start page for MRN 19IT02110010007827


### PR DESCRIPTION
Adding back in until drop session is added back to unloading-frontend.