### PR TITLE
CTCTRADERS-442 | Updating to use arrival id instead of mrn

### DIFF
--- a/src/test/resources/features/UnloadingRemarksWithSeals.feature
+++ b/src/test/resources/features/UnloadingRemarksWithSeals.feature
@@ -1,22 +1,22 @@
 @unloading_remarks
 
-Feature: Ability to submit unloading remarks
+Feature: Ability to submit unloading remarks with seals
 
   Background: Trader selects to add unloading remarks
 
     Given I clear my cookies
-
-  Scenario: 1 - Unloading remarks with seals, no changes to seals but have other changes to report
-
-    And I am on the Unloading remarks start page for MRN 19IT02110010007827
+    And I am on the Unloading remarks start page for Arrival Id 1
     When I clicked the submit button
-    Then I should be on the date goods unloaded page
-    When I input date 24/03/2020 on the date goods unloaded page
+    Then I should be on the Date goods unloaded page
+    When I input date 24/03/2020 on the Date goods unloaded page
     When I answer Yes on the can seals be read page
     When I answer No on the are any seals broken page
     Then I should be on the unloading summary page
-    Then I click the Add comment link
-    When I enter stowaways found on the changes to report page
+
+  Scenario: 1 - Unloading remarks with seals, no changes to seals but have other changes to report
+
+    When I click the Add comment link
+    And I enter stowaways found on the changes to report page
     Then I should be on the unloading summary page
     When I clicked the remove-comment button
     When I answer No on the confirm remove comments page
@@ -27,14 +27,7 @@ Feature: Ability to submit unloading remarks
     Then I should be on the confirmation page
 
   Scenario: 2 - Unloading remarks with changes to summary answers
-
-    And I am on the Unloading remarks start page for MRN 19IT02110010007827
-    When I clicked the submit button
-    Then I should be on the date goods unloaded page
-    When I input date 24/03/2020 on the date goods unloaded page
-    When I answer Yes on the can seals be read page
-    When I answer No on the are any seals broken page
-    Then I should be on the unloading summary page
+    
     When I click on change vehicle reference
     And I enter NE20 CTC on the change vehicle name registration reference page
     Then I should be on the unloading summary page
@@ -62,13 +55,6 @@ Feature: Ability to submit unloading remarks
   @a11y
   Scenario: 3 - Unloading Remarks with seals, adds new seals and changes the check seals section from CYA page
 
-    And I am on the Unloading remarks start page for MRN 19IT02110010007827
-    When I clicked the submit button
-    Then I should be on the Date goods unloaded page
-    When I input date 24/03/2020 on the Date goods unloaded page
-    When I answer Yes on the can seals be read page
-    When I answer No on the are any seals broken page
-    Then I should be on the unloading summary page
     When I click the Add a new seal number link
     And I enter Seal123xyz found on the new seal number page
     Then I should be on the unloading summary page
@@ -85,16 +71,3 @@ Feature: Ability to submit unloading remarks
     Then I should be on the check your answers page
     When I clicked the submit button
     Then I should be on the confirmation page
-
-  Scenario: 4 - Unloading remarks without seals, with no changes to report
-
-    And I am on the Unloading remarks start page for MRN 99IT9876AB88901209
-    When I clicked the submit button
-    Then I should be on the date goods unloaded page
-    When I input date 24/03/2020 on the date goods unloaded page
-    Then I should be on the unloading summary page
-    When I clicked the submit button
-    Then I should be on the check your answers page
-    When I clicked the submit button
-    Then I should be on the confirmation page
-

--- a/src/test/resources/features/UnloadingRemarksWithoutSeals.feature
+++ b/src/test/resources/features/UnloadingRemarksWithoutSeals.feature
@@ -1,0 +1,20 @@
+@unloading_remarks
+
+Feature: Ability to submit unloading remarks without seals
+
+  Background: Trader selects to add unloading remarks
+
+    Given I clear my cookies
+
+  Scenario: 1 - Unloading remarks without seals, with no changes to report
+
+    And I am on the Unloading remarks start page for Arrival Id 2
+    When I clicked the submit button
+    Then I should be on the date goods unloaded page
+    When I input date 24/03/2020 on the date goods unloaded page
+    Then I should be on the unloading summary page
+    When I clicked the submit button
+    Then I should be on the check your answers page
+    When I clicked the submit button
+    Then I should be on the confirmation page
+

--- a/src/test/scala/ctc/pages/Page.scala
+++ b/src/test/scala/ctc/pages/Page.scala
@@ -103,7 +103,7 @@ trait Page extends Matchers with ScreenShotUtility {
 
   def authenticate(arrivalId: String) = {
     goToAuthPage()
-    val redirectUrl = s"${Configuration.settings.applicationsBaseUrl}/$arrivalId/unloading-guidance"
+    val redirectUrl = s"${Configuration.settings.applicationsBaseUrl}/$arrivalId"
     fillInput(By.cssSelector("*[name='redirectionUrl']"), redirectUrl)
     fillInput(By.cssSelector("*[name='enrolment[1].name']"), "HMCE-NCTS-ORG")
     fillInput(By.cssSelector("*[name='enrolment[1].taxIdentifier[0].name']"), "VATRegNoTURN")

--- a/src/test/scala/ctc/pages/Page.scala
+++ b/src/test/scala/ctc/pages/Page.scala
@@ -101,9 +101,9 @@ trait Page extends Matchers with ScreenShotUtility {
     webDriver.navigate().to(authUrl)
   }
 
-  def authenticate(mrn: String) = {
+  def authenticate(arrivalId: String) = {
     goToAuthPage()
-    val redirectUrl = s"${Configuration.settings.applicationsBaseUrl}/$mrn/unloading-guidance"
+    val redirectUrl = s"${Configuration.settings.applicationsBaseUrl}/$arrivalId/unloading-guidance"
     fillInput(By.cssSelector("*[name='redirectionUrl']"), redirectUrl)
     fillInput(By.cssSelector("*[name='enrolment[1].name']"), "HMCE-NCTS-ORG")
     fillInput(By.cssSelector("*[name='enrolment[1].taxIdentifier[0].name']"), "VATRegNoTURN")
@@ -117,8 +117,8 @@ trait Page extends Matchers with ScreenShotUtility {
     urlShouldMatch("movement-reference-number")
   }
 
-  def goToUnloadingRemarksHomePage(mrn: String): Unit = {
-    authenticate(mrn)
+  def goToUnloadingRemarksHomePage(arrivalId: String): Unit = {
+    authenticate(arrivalId)
     urlShouldMatch("unloading-guidance")
   }
 

--- a/src/test/scala/ctc/steps/CommonSteps.scala
+++ b/src/test/scala/ctc/steps/CommonSteps.scala
@@ -16,9 +16,9 @@ class CommonSteps extends ScalaDsl with EN with ScreenShotUtility {
     Page.goToArrivalHomePage()
   }
 
-  Given("""^I am on the Unloading remarks start page for MRN (.*)$""") {
-    (mrn: String) =>
-      Page.goToUnloadingRemarksHomePage(mrn)
+  Given("""^I am on the Unloading remarks start page for Arrival Id (.*)$""") {
+    (arrivalId: String) =>
+      Page.goToUnloadingRemarksHomePage(arrivalId)
   }
 
   Given("""^I am on the home page$""") {


### PR DESCRIPTION
Changes for index page are required to allow the frontend to redirect correctly based on the presence of user-answers or not.